### PR TITLE
Add hcloud_firewall resource (allowing ICMP and SSH) and attach to server

### DIFF
--- a/hcloud.tf
+++ b/hcloud.tf
@@ -16,12 +16,38 @@ data "template_file" "cloud_init" {
 #  value = "${data.template_file.cloud_init.rendered}"
 #}
 
+# Allow only incoming ICMP and SSH
+resource "hcloud_firewall" "k3s-firewall" {
+  name = "k3s-firewall"
+
+  rule {
+    direction = "in"
+    protocol = "icmp"
+    source_ips = [
+      "0.0.0.0/0",
+      "::/0"
+    ]
+  }
+
+  rule {
+    direction = "in"
+    protocol = "tcp"
+    port = "22"
+    source_ips = [
+      "0.0.0.0/0",
+      "::/0"
+    ]
+  }
+}
+
 # Create a server
 resource "hcloud_server" "k3s" {
   name        = "${var.env_name}-k3s"
   image       = "${var.node_image}"
   server_type = "${var.server_type}"
   ssh_keys = [ data.hcloud_ssh_key.ssh_key.id]
+
+  firewall_ids = [ hcloud_firewall.k3s-firewall.id ]
 
   user_data = "${data.template_file.cloud_init.rendered}"
 


### PR DESCRIPTION
I have added a hcloud_firewall resource, configured it with only incoming ICMP and SSH (22/TCP) allowed and attached to the server.
I have, however not tested it yet... let's not merge this until it is tested.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change prevents the K3s cluster (or any other resource on the deployed server for that matter) to be accessible from the internet. Restricting K3s to internal IPs is quite involved due to its rather complicated network setup so this was deemed to be the easier but still effective solution.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
